### PR TITLE
Change *_LIBRARIES to *_LDFLAGS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,7 +99,7 @@ if (USE_QT4)
 endif()
 
 target_link_libraries(obconf-qt
-  ${QTX_LDFLAGS}
+  ${QTX_LIBRARIES}
   ${GLIB_LDFLAGS}
   ${OPENBOX_LDFLAGS}
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,9 +99,9 @@ if (USE_QT4)
 endif()
 
 target_link_libraries(obconf-qt
-  ${QTX_LIBRARIES}
-  ${GLIB_LIBRARIES}
-  ${OPENBOX_LIBRARIES}
+  ${QTX_LDFLAGS}
+  ${GLIB_LDFLAGS}
+  ${OPENBOX_LDFLAGS}
 )
 
 install(TARGETS obconf-qt RUNTIME DESTINATION bin)


### PR DESCRIPTION
Spotted when making a port for OpenBSD, some flags are missing if you use, for example, ${OPENBOX_LIBRARIES} instead of ${OPENBOX_LDFLAGS}.
Upgrade in portability to other non-linux systems.