### PR TITLE
Handle ldflags when the module library is not installed in a system dir.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,7 +101,7 @@ endif()
 target_link_libraries(obconf-qt
   ${QTX_LIBRARIES}
   ${GLIB_LIBRARIES}
-  ${OPENBOX_LIBRARIES}
+  ${OPENBOX_LDFLAGS}
 )
 
 install(TARGETS obconf-qt RUNTIME DESTINATION bin)


### PR DESCRIPTION
Some OSes use other locations for their libraries.
This adds those locations to the linker flags avoiding missing libraries.