### PR TITLE
Use lxqt-build-tools FindGLib CMake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,11 +37,9 @@ endif()
 
 find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 
-find_package(PkgConfig)
-pkg_check_modules(GLIB REQUIRED
-  glib-2.0
-)
+find_package(GLIB REQUIRED)
 
+find_package(PkgConfig)
 pkg_check_modules(OPENBOX REQUIRED
   obrender-3.5
   obt-3.5


### PR DESCRIPTION
We weren't using it. It finds and handles GLib even when installed into a
non system directory.