### PR TITLE
Remove unused variables

### DIFF
--- a/src/appearance.cpp
+++ b/src/appearance.cpp
@@ -121,7 +121,7 @@ void MainDialog::on_font_inactive_display_changed() {
 static RrFont* read_font(Fm::FontButton* button, const gchar* place,
                          gboolean use_default) {
   RrFont* font;
-  gchar* fontstring, *node;
+  gchar* node;
   gchar* name, **names;
   gchar* size;
   gchar* weight;
@@ -180,7 +180,6 @@ static RrFont* read_font(Fm::FontButton* button, const gchar* place,
   if(!g_ascii_strcasecmp(slant, "Oblique")) rr_slant = RR_FONTSLANT_OBLIQUE;
 
   font = RrFontOpen(rrinst, name, atoi(size), rr_weight, rr_slant);
-  // g_free(fontstring);
   g_free(slant);
   g_free(weight);
   g_free(size);
@@ -190,7 +189,6 @@ static RrFont* read_font(Fm::FontButton* button, const gchar* place,
 }
 
 static RrFont* write_font(Fm::FontButton* button, const gchar* place) {
-  gchar *c;
   gchar *node;
   RrFontWeight weight = RR_FONTWEIGHT_NORMAL;
   RrFontSlant slant = RR_FONTSLANT_NORMAL;

--- a/src/desktops.cpp
+++ b/src/desktops.cpp
@@ -104,9 +104,7 @@ void MainDialog::desktops_read_names() {
 }
 
 void MainDialog::desktops_write_names() {
-  gchar** s;
   xmlNodePtr n, c;
-  gint num = 0, last = -1;
 
   // delete all existing keys
   n = tree_get_node("desktops/names", NULL);

--- a/src/obconf-qt.cpp
+++ b/src/obconf-qt.cpp
@@ -196,8 +196,6 @@ int main(int argc, char** argv) {
   app.installTranslator(&translator);
 
   // load configurations
-  gchar* p;
-  gboolean exit_with_error = FALSE;
 
   parse_args(argc, argv);
 
@@ -226,7 +224,6 @@ int main(int argc, char** argv) {
                                 "openbox_config"))) {
     QMessageBox::critical(NULL, QObject::tr("Error"),
                           QObject::tr("Failed to load an rc.xml. You have probably failed to install Openbox properly."));
-    exit_with_error = TRUE;
   }
   else {
     doc = obt_xml_doc(parse_i);
@@ -241,7 +238,6 @@ int main(int argc, char** argv) {
       QString message = QObject::tr("Error while parsing the Openbox configuration file.  Your configuration file is not valid XML.\n\nMessage: %1")
         .arg(QString::fromUtf8(e->message));
       QMessageBox::critical(NULL, QObject::tr("Error"), message);
-      exit_with_error = TRUE;
     }
   }
 

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -48,7 +48,6 @@ void MainDialog::theme_load_all() {
   gchar* p;
   GList* it, *next;
   gint i;
-  RrFont* active, *inactive, *menu_t, *menu_i, *osd;
   QModelIndex currentItemIndex;
 
   name = tree_get_string("theme/name", "TheBear");


### PR DESCRIPTION
Fixes compilation warnings for unused-variables [-Wunused-variable] and
unused but set variables [-Wunused-but-set-variable] with Gcc.