### PR TITLE
Fix reorder compiler warning

### DIFF
--- a/src/maindialog.cpp
+++ b/src/maindialog.cpp
@@ -28,9 +28,9 @@
 using namespace Obconf;
 
 MainDialog::MainDialog():
+  QDialog(),
   themes(NULL),
-  themes_model(new QStandardItemModel()),
-  QDialog() {
+  themes_model(new QStandardItemModel()) {
 
   ui.setupUi(this);
   setWindowIcon(QIcon(PIXMAPS_DIR "/obconf-qt.png"));


### PR DESCRIPTION
Fixes Wreorder compiler warning when compiling with Gcc:

    In file included from /home/r/obconf-qt/src/maindialog.cpp:24:
    /home/r/obconf-qt/src/maindialog.h: In constructor ‘Obconf::MainDialog::MainDialog()’:
    /home/r/obconf-qt/src/maindialog.h:162:23: warning: ‘Obconf::MainDialog::themes_model’ will be initialized after [-Wreorder]
       QStandardItemModel* themes_model;
                       ^~~~~~~~~~~~
    /home/r/obconf-qt/src/maindialog.cpp:33:11: warning:   base ‘QDialog’ [-Wreorder]
       QDialog() {
           ^
    /home/r/obconf-qt/src/maindialog.cpp:30:1: warning:   when initialized here [-Wreorder]
     MainDialog::MainDialog():