### PR TITLE
Fix for the usage of memory after freed

### DIFF
--- a/src/moveresize.cpp
+++ b/src/moveresize.cpp
@@ -95,10 +95,10 @@ void MainDialog::moveresize_setup_tab() {
   else if(opp) pos = EDGE_RIGHT;
   else pos = EDGE_LEFT;
 
-  g_free(s);
-
   ui.fixed_y_popup->setCurrentIndex(pos);
   ui.fixed_y_pos->setValue(MAX(atoi(s), 0));
+    
+  g_free(s);
 
   i = tree_get_int("mouse/screenEdgeWarpTime", 400);
 


### PR DESCRIPTION
This is the most naive fix I could imagine for https://github.com/lxqt/obconf-qt/issues/83
I hope it is rational enough and breaks nothing