### PR TITLE
Fix instllation message in archive_install()

### DIFF
--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -23,7 +23,7 @@ gchar* archive_install(const gchar *path)
         return NULL;
 
     if ((name = install_theme_to(path, dest))) {
-      QMessageBox::information(NULL, QString(), QObject::tr("\"%1\" was installed to %1")
+      QMessageBox::information(NULL, QString(), QObject::tr("\"%1\" was installed to %2")
         .arg(QString::fromUtf8(name))
         .arg(QString::fromUtf8(dest)));
     }


### PR DESCRIPTION
Message:
```
	"%1" was installed to %1 ->
	"%1" was installed to %2
	~~~~~~~~~~~~~~~~~~~~~~~^
```
Before: screenshot
![obconf-qt_message-Before](https://user-images.githubusercontent.com/52656419/63232686-4664b000-c265-11e9-91d8-471768a3c189.jpg)

After: screenshot
![obconf-qt_message_After](https://user-images.githubusercontent.com/52656419/63232689-4d8bbe00-c265-11e9-9772-2a0d938f5ea9.jpg)


I am doing Japanese translation in Weblate.
I noticed it when translating.

<https://weblate.lxqt.org/translate/lxqt/obconf-qt/ja/?checksum=62a775aca249187f>
I read `to %1` as `to %2` and translated it into Japanese.
