### PR TITLE
Fix license

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,5 +9,5 @@ Original authors of obconf and copyright notice:
     Copyright (c) 2003 Tim Riley <tr@slackzone.org>
     Copyright (c) 2007 Javeed Shaikh <syscrash2k@gmail.com>
 
-License: GNU GPL-2
+License: GPL-2.0-or-later
 The full text of the licenses can be found in the 'COPYING' file.


### PR DESCRIPTION
All `src/*.cpp` and `src/*.h` files with a license header mention "any later version"

Closes https://github.com/lxqt/obconf-qt/issues/210