### PR TITLE
FIX: support compilation with libxml2 2.12.0

### DIFF
--- a/src/obconf-qt.cpp
+++ b/src/obconf-qt.cpp
@@ -230,7 +230,7 @@ int main(int argc, char** argv) {
 
   /* look for parsing errors */
   {
-    xmlErrorPtr e = xmlGetLastError();
+    const xmlError* e = xmlGetLastError();
 
     if(e) {
       QString message = QObject::tr("Error while parsing the Openbox configuration file.  Your configuration file is not valid XML.\n\nMessage: %1")


### PR DESCRIPTION
@tsujan,
libxml2 2.12.0 now makes xmlGetLastError() return const pointer: https://gitlab.gnome.org/GNOME/libxml2/-/commit/45470611b047db78106dcb2fdbd4164163c15ab7

Fix variable type using xmlGetLastError() as such.