### PR TITLE
Expose allDesktops option from rc.xml in the desktop section

### DIFF
--- a/src/desktops.cpp
+++ b/src/desktops.cpp
@@ -33,6 +33,9 @@ extern RrInstance* rrinst; // defined in obconf-qt.cpp
 
 static int num_desktops;
 
+static const gchar* all_desktops_node_1 = "keyboard/keybind:key=A-Tab/action:name=NextWindow/allDesktops";
+static const gchar* all_desktops_node_2 = "keyboard/keybind:key=A-S-Tab/action:name=PreviousWindow/allDesktops";
+
 /*
 static void desktops_read_names();
 static void desktops_write_names();
@@ -52,6 +55,9 @@ void MainDialog::desktops_setup_tab() {
   i = tree_get_int("desktops/popupTime", 875);
   ui.desktop_popup->setChecked(i != 0);
   ui.desktop_popup_time->setValue(i ? i : 875);
+
+  gboolean all_desktops = tree_get_bool(all_desktops_node_1, TRUE);
+  ui.all_desktops->setChecked(all_desktops);
 }
 
 void MainDialog::on_desktop_num_valueChanged(int newValue) {
@@ -165,6 +171,11 @@ void MainDialog::on_desktop_popup_toggled(bool checked) {
   }
   else
     tree_set_int("desktops/popupTime", 0);
+}
+
+void MainDialog::on_all_desktops_toggled(bool checked) {
+  tree_set_bool(all_desktops_node_1, checked);
+  tree_set_bool(all_desktops_node_2, checked);
 }
 
 void MainDialog::on_desktop_popup_time_valueChanged(int newValue) {

--- a/src/maindialog.h
+++ b/src/maindialog.h
@@ -142,6 +142,7 @@ private Q_SLOTS:
   void on_desktop_popup_toggled(bool checked);
   void on_desktop_popup_time_valueChanged(int newValue);
   void on_desktop_names_itemChanged(QListWidgetItem * item);
+  void on_all_desktops_toggled(bool checked);
 
   // docks
   void on_dock_float_x_valueChanged(int newValue);

--- a/src/obconf.ui
+++ b/src/obconf.ui
@@ -870,10 +870,17 @@ D: Omnipresent (On all desktops)</string>
            </property>
           </widget>
          </item>
+         <item row="4" column="0">
+          <widget class="QCheckBox" name="all_desktops">
+           <property name="text">
+            <string>&amp;Show windows from all desktops when task switching (Alt-Tab)</string>
+           </property>
+          </widget>
+         </item>
          <item row="9" column="0" colspan="2">
           <widget class="QListWidget" name="desktop_names"/>
          </item>
-         <item row="4" column="0" colspan="2">
+         <item row="6" column="0" colspan="2">
           <widget class="QLabel" name="label_19">
            <property name="text">
             <string>&amp;Desktop names:</string>
@@ -1381,6 +1388,10 @@ D: Omnipresent (On all desktops)</string>
      <y>39</y>
     </hint>
    </hints>
+  </connection>
+  <connection>
+   <sender>all_desktops</sender>
+   <signal>toggled(bool)</signal>
   </connection>
   <connection>
    <sender>dock_hide</sender>


### PR DESCRIPTION
See issue [#252](https://github.com/lxqt/obconf-qt/issues/252)

Some UX and technical aspects complicate things. The "allDesktops" option is fairly buried in the keybindings in the xml, hence the strings for the node names. I guess there's potential for something to break if some other program is used for remapping those. 

There seems to be a tension between the separation of concerns between the window manager and desktop environment. Also, whether this belongs in the "Desktops" section of obconf-qt, the "Windows" section, or a separate section, I'm not altogther sure. 