### PR TITLE
Assign file dialog to the parent window

### DIFF
--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -158,7 +158,7 @@ void MainDialog::on_install_theme_clicked() {
 }
 
 void MainDialog::on_theme_archive_clicked() {
-    QFileDialog* dialog = new QFileDialog();
+    QFileDialog* dialog = new QFileDialog(this);
     dialog->setFileMode(QFileDialog::Directory);
     QString filename=QLatin1String("");
     if(dialog->exec())


### PR DESCRIPTION
This ensures that the dialog is attached to the main window.